### PR TITLE
Update main_SingleRun.cu

### DIFF
--- a/DSDP_blind_docking/main_SingleRun.cu
+++ b/DSDP_blind_docking/main_SingleRun.cu
@@ -135,7 +135,7 @@ int main(int argn, char* argv[])
 	std::vector<float> vbox_min, vbox_max;
 
 	app.description("DSDP: Deep Site and Docking Pose\n"
-		" This is the re-docking program.\n"
+		" This is the blind-docking program.\n"
 		" More details at https://github.com/PKUGaoGroup/DSDP");
 
 	app.add_option("--ligand", ligand_string, "ligand input PDBQT file [REQUIRED]")


### PR DESCRIPTION
In the "DSDP_blind_docking/" path, the main_SingleRun.cu file on line 138 has the code "This is the re-docking program.\n" which may confuse users. Consider changing it to "This is the blind-docking program.\n".